### PR TITLE
Adding CapybaraSpa::Server::ExternalServer

### DIFF
--- a/lib/capybara_spa.rb
+++ b/lib/capybara_spa.rb
@@ -1,18 +1,19 @@
-require File.join(File.dirname(__FILE__), 'capybara_spa/capybara_dsl_ext')
-require File.join(File.dirname(__FILE__), 'capybara_spa/server/ng_static_server')
-
 module CapybaraSpa
   class << self
-    #  * NG_APP_TAG: the HTML tag where the angular app is stored. Defaults to app-root.
+    # +app_tag+ is the HTML tag where the single page application is stored. Defaults to app-root. \
+    #   This can be set thru the SPA_APP_TAG environment variable.
     attr_accessor :app_tag
 
-    #  * NG_LOG_FILE: where to log the output of angular-http-server. Defaults to /dev/null
+    # +log_file+ where to log the output of angular-http-server. Defaults to /dev/null \
+    #   This can be set thru the SPA_LOG_FILE environment variable.
     attr_accessor :log_file
   end
 
-  self.app_tag = ENV.fetch('NG_APP_TAG', 'app-root')
-  self.log_file = ENV.fetch('NG_LOG_FILE', STDOUT)
-
-  module Server
-  end
+  self.app_tag = ENV.fetch('SPA_APP_TAG', 'app-root')
+  self.log_file = ENV.fetch('SPA_LOG_FILE', STDOUT)
 end
+
+require File.join(File.dirname(__FILE__), 'capybara_spa/capybara_dsl_ext')
+require File.join(File.dirname(__FILE__), 'capybara_spa/server')
+require File.join(File.dirname(__FILE__), 'capybara_spa/server/external_server')
+require File.join(File.dirname(__FILE__), 'capybara_spa/server/ng_static_server')

--- a/lib/capybara_spa/server.rb
+++ b/lib/capybara_spa/server.rb
@@ -1,0 +1,5 @@
+module CapybaraSpa
+  module Server
+    class Error < ::StandardError ; end
+  end
+end

--- a/lib/capybara_spa/server/external_server.rb
+++ b/lib/capybara_spa/server/external_server.rb
@@ -1,0 +1,102 @@
+require 'socket'
+require 'timeout'
+
+module CapybaraSpa
+  module Server
+    class ExternalServerNotFoundOnPort < Error ; end
+    class ExternalServerStillRunning < Error ; end
+
+    # CapybaraSpa::Server::ExternalServer is a class that wraps a server running as
+    # as an external process. For example, let's say you wanted to always have an
+    # a version of your single-page-application up and running for integration tests.
+    # You would start this in a different terminal or shell like this:
+    #
+    #     ng serve --port 5001
+    #
+    # Then you would configure your CapybaraSpa server in your test helper (e.g. \
+    # spec_helper.rb, rails_helper.rb, etc):
+    #
+    #   server = CapybaraSpa::Server::ExternalServer.new(
+    #     port: 5001
+    #   )
+    #
+    class ExternalServer
+      # +host+ is a string of the host or ip address to connect to
+      attr_accessor :host
+
+      # +port+ is port number that the external process is running on
+      attr_accessor :port
+
+      # +start_timeout+ is the number of seconds to wait for the external process
+      # to begin listening on +port+. Applies to #start and #started?
+      attr_accessor :start_timeout
+
+      # +stop_timeout+ is the number of seconds to wait when determining the external
+      # process is no longer running. Applies to #stop and #stopped?
+      attr_accessor :stop_timeout
+
+      def initialize(host: 'localhost', port: 5001, start_timeout: 60, stop_timeout: 1)
+        @host = host
+        @port = port
+        @start_timeout = start_timeout
+        @stop_timeout = stop_timeout
+      end
+
+      # +start+ is a no-op, but it will wait up to the +start_timeout+ for the external
+      # process to start listening on the specified +port+ before giving up and raising
+      # an ExternalServerNotFoundOnPort error.
+      def start
+        unless is_port_open?(timeout: start_timeout)
+          raise ExternalServerNotFoundOnPort, <<-ERROR.gsub(/^\s*\|/, '')
+            |Tried for #{start_timeout} seconds but nothing was listening
+            |on port #{port}. Please make sure the external process is running
+            |successfully and that the port is correct.
+          ERROR
+        end
+      end
+
+      # Returns true if the an external process is running on the +host+ and +port+.
+      # Otherwise, returns false.
+      def started?
+        is_port_open?(timeout: start_timeout)
+      end
+
+      # +stop+ is a no-op, but it will wait up to the +stop_timeout+ for the external
+      # process to stop listening on the specified +port+ before giving up
+      # and raising an ExternalServerStillRunning error.
+      def stop
+        unless !is_port_open?(timeout: stop_timeout)
+          raise ExternalServerStillRunning, <<-ERROR.gsub(/^\s*\|/, '')
+            |I tried for #{stop_timeout} seconds to verify that the
+            |external process listening on #{port} had stopped listening,
+            |but it hasn't. You may have a zombie process
+            |or may need to increase the stop_timeout.
+          ERROR
+        end
+      end
+
+      # Returns true if the an external process is not running on the +host+ and +port+.
+      # Otherwise, returns true.
+      def stopped?
+        !is_port_open?(timeout: stop_timeout)
+      end
+
+      private
+
+      def is_port_open?(timeout: 10)
+        Timeout.timeout(timeout) do
+          begin
+            s = TCPSocket.new(host, port)
+            s.close
+            return true
+          rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+            sleep 1
+            retry
+          end
+        end
+      rescue Timeout::Error
+        return false
+      end
+    end
+  end
+end

--- a/spec/capybara_spa/server/external_server_spec.rb
+++ b/spec/capybara_spa/server/external_server_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+require 'timeout'
+
+describe CapybaraSpa::Server::ExternalServer, js: true do
+  let(:spec_dir) { File.expand_path File.join(File.dirname(__FILE__), '../../') }
+  let(:tmp_dir) { File.expand_path File.join(spec_dir, '..', 'tmp') }
+  let(:angular_app_path) { File.join spec_dir, 'angular-app' }
+  let(:node_modules_path) {  File.join angular_app_path, 'node_modules' }
+  let(:ng_bin_path) { File.join node_modules_path, '.bin/ng' }
+
+  let(:server) do
+    CapybaraSpa::Server::ExternalServer.new(server_args)
+  end
+
+  let(:default_constructor_args) { {} }
+  let(:server_args) { default_constructor_args }
+
+  def spawn_cmd(cmd)
+    # use spawn(cmd, arg1, ... ) version to avoid launching a shell that launches the
+    # http-server or ng process. We want this pid to be the actual process to kill when
+    # this program is done exiting.
+    pid = spawn *cmd.split(/\s+/)
+
+    at_exit do
+      begin
+        Process.kill 'TERM', pid
+        Process.wait pid
+      rescue Errno::ECHILD, Errno::ESRCH
+        # no-op: the process is already dead
+      end
+    end
+
+    pid
+  end
+
+  context 'when no external process is running on the given port' do
+    it 'can tell you that the process is not running' do
+      server.start_timeout = 1
+      expect(server.started?).to be false
+
+      server.stop_timeout = 1
+      expect(server.stopped?).to be true
+    end
+
+    it 'raises an exception when it cannot connect to the server by +start_timeout+ seconds' do
+      server.start_timeout = 0.25
+      expect do
+        server.start
+      end.to raise_error CapybaraSpa::Server::ExternalServerNotFoundOnPort
+    end
+  end
+
+  context 'when running against a running process on a given port' do
+    let(:server_args) { { port: 5001 } }
+
+    around do |example|
+      pid = Dir.chdir angular_app_path do
+        spawn_cmd "#{ng_bin_path} serve --port 5001"
+      end
+
+      begin
+        example.run
+      ensure
+        (Process.kill 'TERM', pid rescue Errno::ESRCH) if pid
+      end
+    end
+
+    it 'can tell you that the process is running' do
+      expect(server.started?).to be true
+      expect(server.stopped?).to be false
+    end
+
+    it 'can run Capybara tests against the running process' do
+      visit '/'
+      expect(page).to have_content('Welcome to app!')
+    end
+
+    it 'raises an exception when told the server has stopped and it does not stop within +stop_timeout+ seconds' do
+      server.stop_timeout = 0.25
+      expect do
+        server.stop
+      end.to raise_error CapybaraSpa::Server::ExternalServerStillRunning
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,6 @@ Bundler.require(:default, :test)
 require 'capybara/rspec'
 require 'selenium/webdriver'
 
-
 require 'capybara_spa'
 
 chrome_options = {}


### PR DESCRIPTION
## What this PR does?

This PR adds `CapybaraSpa::Server::ExternalServer` for running an external process separate from the test process in which Capybara runs.